### PR TITLE
Add basic reactivity chapter

### DIFF
--- a/03-basic_reactivity.Rmd
+++ b/03-basic_reactivity.Rmd
@@ -1,14 +1,4 @@
----
-title: "Mastering Shiny: Ch-4"
-output: 
-  html_document:
-    code_folding: hide
-runtime: shiny
----
-
-```{r setup, include=FALSE}
-knitr::opts_chunk$set(echo = TRUE)
-```
+# Basic Reactivity
 
 ##  {.tabset}
 

--- a/03-basic_reactivity.Rmd
+++ b/03-basic_reactivity.Rmd
@@ -1,0 +1,203 @@
+---
+title: "Mastering Shiny: Ch-4"
+output: 
+  html_document:
+    code_folding: hide
+runtime: shiny
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(echo = TRUE)
+```
+
+##  {.tabset}
+
+```{r setup , message=FALSE, echo=FALSE}
+library(DiagrammeR)
+```
+
+### Chapter Notes
+
+
+```{r intro graph, echo=FALSE}
+
+mermaid("
+graph LR
+A[R scripting]-->B[sequential logic]
+")
+
+mermaid("
+graph LR
+A[Reactive Programming]-->B[graph of dependencies]
+")
+
+```
+
+Important Learnings so far, main app components:
+
+1. Front end - the ui object
+
+-   contains the HTML presented to every user of your app.
+-   is simple because **every user** gets the **same** HTML.
+
+2.  Back end - the server object
+
+-   is more complicated because **every user** needs to get an **independent version** of the app (when user A modifies an input field, user B shouldn't see their outputs change).
+-   creates a new environment for each run, giving each session to have a unique state.      
+
+
+> server <- function(input, output, session)
+
+1 _input_       
+- list-like object       
+- used for receiving input( sent from the browser)       
+- read-only       
+- must be read in a reactive context (e.g. renderText() or reactive())      
+
+
+2 _output_     
+- list-like object      
+- used for sending output       
+- ALWAYS use with a render fn() - sets up the reactive context & renders the HTML.      
+
+
+```{r}
+ui <- fluidPage(
+  textInput("name", "What's your name?"),
+  textOutput("greeting")
+)
+
+server <- function(input, output, session) {
+  output$greeting <- renderText({
+    paste0("Hello ", input$name, "!")
+  })
+}
+```
+
+Mental Model       
+- tell vs inform (providing Shiny with recipes, not giving it commands).        
+
+****
+
+**Imperative vs declarative programming**        
+This difference between commands and recipes is one of the key differences between two important styles of programming:         
+- _Imperative_ programming - issue a specific command and it’s carried out immediately.       
+- _Declarative_ programming - express higher-level goals or describe important constraints, and rely on someone else to decide how and/or when to translate that into action.       
+
+- Imperative code is assertive; vs declarative code is passive-aggressive       
+- “Make me a sandwich” vs “Ensure there is a sandwich in the refrigerator whenever I look inside of it”       
+
+In essesnce, you describe your overall goals, and the software figures out how to achieve them without further intervention. 
+
+****
+**Laziness**       
+It allows apps to be extremely lazy. A Shiny app will only ever do the minimal amount of work needed to update the output controls that you can currently see.
+
+_CAUTION_: If you’re working on a Shiny app and you just can’t figure out why your code never gets run, double check that your UI and server functions are using the same identifiers. 
+
+****
+**The reactive graph**      
+- understanding order of execution
+- code is only run when needed
+
+_reactive graph_ 
+- describes how inputs and outputs are connected
+- describe this relationship (`output` has a reactive dependency on `input`)
+
+
+```{r reactive graph}
+mermaid("
+graph LR
+A[name] --- B>greeting]
+")
+```
+
+reactive graph is a powerful tool for understanding how your app works.       
+- Make by hand     
+- Use DiagrammeR pkg to make it manually yourself     
+- Use `reactlog` pkg to do it automatically (more in later chapters)       
+
+****
+**Reactive expressions**         
+**What** - A tool that **reduces duplication** in your reactive code by introducing additional nodes into the reactive graph       
+**How** - using `reactive()`      
+
+
+```{r}
+# Just for example
+
+server <- function(input, output, session) {
+  string <- reactive(paste0("Hello ", input$name, "!"))
+  output$greeting <- renderText(string())
+}
+
+```
+
+```{r reactive graph with reactive() , echo=FALSE}
+
+mermaid("
+graph LR
+A[name] --- B>string]
+B>string] --- C>greeting]
+")
+
+```
+
+In other words , makes app cleaner & more efficient (by removing redundant codes & recomputation).
+It also simplifies the reactive graph.
+
+Reactive expressions have a flavour of both inputs and outputs:
+
+- Like inputs, you can use the results of a reactive expression in an output.
+- Like outputs, reactive expressions depend on inputs and automatically know when they need updating.
+
+New vocab:
+
+- producers to refer to reactive inputs and expressions, and 
+- consumers to refer to reactive expressions and outputs
+
+****
+**Execution order**         
+- determined solely by the reactive graph (and not the order of lines of code/layout in the _server_ fn unlike normal R scripts)
+
+
+****
+**Controlling timing of evaluation**          
+
+**_Timed invalidation_**        
+**How** - using `reactiveTimer()`
+
+
+**_On click_**       
+**How** - using `actionButton()`, `eventReactive()`      
+
+****
+**Observers**         
+
+There are two important differences between `observeEvent()` and `eventReactive()`:
+
+1.  You don't/can't assign the result of observeEvent() to a variable, so\
+2.  You can't refer to it from other reactive consumers.
+
+****
+
+### Execises
+
+```{r example}
+mermaid("
+graph LR
+A(Rounded)-->B[Rectangular]
+B-->C{A Rhombus}
+C-->D[Rectangle One]
+C-->E[Rectangle Two]
+")
+```
+
+```{r reactive graph}
+
+mermaid("
+graph LR
+A[A arr_text] --- B>A arrowtext]
+")
+
+```

--- a/03-basic_reactivity.Rmd
+++ b/03-basic_reactivity.Rmd
@@ -9,7 +9,7 @@ library(DiagrammeR)
 ### Chapter Notes
 
 
-```{r intro graph, echo=FALSE}
+```{r intro-graph, echo=FALSE}
 
 mermaid("
 graph LR
@@ -95,7 +95,7 @@ _reactive graph_
 - describe this relationship (`output` has a reactive dependency on `input`)
 
 
-```{r reactive graph}
+```{r reactive-graph}
 mermaid("
 graph LR
 A[name] --- B>greeting]
@@ -123,7 +123,7 @@ server <- function(input, output, session) {
 
 ```
 
-```{r reactive graph with reactive() , echo=FALSE}
+```{r reactive-graph-with-reactive() , echo=FALSE}
 
 mermaid("
 graph LR
@@ -183,7 +183,7 @@ C-->E[Rectangle Two]
 ")
 ```
 
-```{r reactive graph}
+```{r reactive-graph-exercise}
 
 mermaid("
 graph LR

--- a/03-basic_reactivity.Rmd
+++ b/03-basic_reactivity.Rmd
@@ -1,16 +1,12 @@
 # Basic Reactivity
 
-##  {.tabset}
-
 ```{r setup , message=FALSE, echo=FALSE}
 library(DiagrammeR)
 ```
 
-### Chapter Notes
-
+## Recap
 
 ```{r intro-graph, echo=FALSE}
-
 mermaid("
 graph LR
 A[R scripting]-->B[sequential logic]
@@ -20,7 +16,6 @@ mermaid("
 graph LR
 A[Reactive Programming]-->B[graph of dependencies]
 ")
-
 ```
 
 Important Learnings so far, main app components:
@@ -64,12 +59,13 @@ server <- function(input, output, session) {
 }
 ```
 
+## Reactive Programming
+
 Mental Model       
 - tell vs inform (providing Shiny with recipes, not giving it commands).        
 
-****
+### Imperative vs declarative programming
 
-**Imperative vs declarative programming**        
 This difference between commands and recipes is one of the key differences between two important styles of programming:         
 - _Imperative_ programming - issue a specific command and it’s carried out immediately.       
 - _Declarative_ programming - express higher-level goals or describe important constraints, and rely on someone else to decide how and/or when to translate that into action.       
@@ -79,14 +75,15 @@ This difference between commands and recipes is one of the key differences betwe
 
 In essesnce, you describe your overall goals, and the software figures out how to achieve them without further intervention. 
 
-****
-**Laziness**       
+### Laziness
+
 It allows apps to be extremely lazy. A Shiny app will only ever do the minimal amount of work needed to update the output controls that you can currently see.
 
 _CAUTION_: If you’re working on a Shiny app and you just can’t figure out why your code never gets run, double check that your UI and server functions are using the same identifiers. 
 
-****
-**The reactive graph**      
+
+### The reactive graph
+
 - understanding order of execution
 - code is only run when needed
 
@@ -107,8 +104,8 @@ reactive graph is a powerful tool for understanding how your app works.
 - Use DiagrammeR pkg to make it manually yourself     
 - Use `reactlog` pkg to do it automatically (more in later chapters)       
 
-****
-**Reactive expressions**         
+## Reactive expressions
+
 **What** - A tool that **reduces duplication** in your reactive code by introducing additional nodes into the reactive graph       
 **How** - using `reactive()`      
 
@@ -120,17 +117,14 @@ server <- function(input, output, session) {
   string <- reactive(paste0("Hello ", input$name, "!"))
   output$greeting <- renderText(string())
 }
-
 ```
 
 ```{r reactive-graph-with-reactive() , echo=FALSE}
-
 mermaid("
 graph LR
 A[name] --- B>string]
 B>string] --- C>greeting]
 ")
-
 ```
 
 In other words , makes app cleaner & more efficient (by removing redundant codes & recomputation).
@@ -146,13 +140,12 @@ New vocab:
 - producers to refer to reactive inputs and expressions, and 
 - consumers to refer to reactive expressions and outputs
 
-****
+
 **Execution order**         
 - determined solely by the reactive graph (and not the order of lines of code/layout in the _server_ fn unlike normal R scripts)
 
 
-****
-**Controlling timing of evaluation**          
+## Controlling timing of evaluation
 
 **_Timed invalidation_**        
 **How** - using `reactiveTimer()`
@@ -161,17 +154,14 @@ New vocab:
 **_On click_**       
 **How** - using `actionButton()`, `eventReactive()`      
 
-****
-**Observers**         
+## Observers
 
 There are two important differences between `observeEvent()` and `eventReactive()`:
 
 1.  You don't/can't assign the result of observeEvent() to a variable, so\
 2.  You can't refer to it from other reactive consumers.
 
-****
-
-### Execises
+## Execises
 
 ```{r example}
 mermaid("
@@ -184,10 +174,8 @@ C-->E[Rectangle Two]
 ```
 
 ```{r reactive-graph-exercise}
-
 mermaid("
 graph LR
 A[A arr_text] --- B>A arrowtext]
 ")
-
 ```

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,6 +9,7 @@ Depends:
     R (>= 3.1.0)
 Imports: 
     bookdown,
+    DiagrammeR,
     details,
     emo,
     shiny,


### PR DESCRIPTION
# NOTES re formatting Priyanka's notes for Bookdown

Original file was created by @priyankagagneja
Converted to bookdown format, for consistency with other files by @russHyde

----

- Downloaded Priyanka's file from
[https://raw.githubusercontent.com/priyankagagneja/Self-Learning/main/Book%20Notes/Mastering%20Shiny/Ch-4.Rmd]

- Renamed the file "03-basic_reactivity.Rmd"

- Issue: while viewing the latter file in Rstudio, "Package DiagrammeR required but not installed" error showed

- installed "DiagrammeR" & added as a dependency for the book

    - install.packages("DiagrammeR")
    - usethis::use_package("DiagrammeR")

- Issue: on adding DiagrammeR with usethis, error message indicating that the
  new chapter should have a first-level heading showed up:
  
    Warning messages:
    1: In split_chapters(output, gitbook_page, number_sections, split_by,  :
      You have 5 Rmd input file(s) but only 4 first-level heading(s). Did you
      forget first-level headings in certain Rmd files?
    2: In split_chapters(output, gitbook_page, number_sections, split_by,  :
      You have 5 Rmd input file(s) but only 4 first-level heading(s). Did you
      forget first-level headings in certain Rmd files?

- Added first-level heading for the basic-reactivity chapter
  - and removed the yaml header and knit-options setting code from priyanka's
  standalone Rmd file (since these are provided by bookdown)

- Issue: while previewing the book using bookdown::serve_book(), 

    processing file: bookclub-mshiny.Rmd
        Error in parse_block(g[-1], g[1], params.src, markdown_mode) : 
          Duplicate chunk label 'reactive graph', which has been used for the chunk:
        mermaid("
        graph LR
        A[name] --- B>greeting]
        
- Relabelled all R-code chunks
  - Replaced all chunk-name white-space with "-" ("intro graph" -> "intro-graph")
  - Renamed the second "reactive-graph" chunk as "reactive-graph-exercise"
  
- Labelling of sections
  - Original file was split into sections using "****" to add page-breaks
  - Changed these dividers to use "##" and "###" for sections/subsections of the
  book